### PR TITLE
Fix warnings related to the unsignedness of variables

### DIFF
--- a/robotiq_ft_sensor_hardware/CMakeLists.txt
+++ b/robotiq_ft_sensor_hardware/CMakeLists.txt
@@ -7,6 +7,7 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 add_compile_options(-Wall)
 add_compile_options(-Wextra)
 add_compile_options(-Wno-unused-parameter)
+add_compile_options(-D_DEFAULT_SOURCE)
 
 # find dependencies
 find_package(ament_cmake REQUIRED)

--- a/robotiq_ft_sensor_hardware/include/robotiq_ft_sensor_hardware/robotiq_ft_sensor_hardware.hpp
+++ b/robotiq_ft_sensor_hardware/include/robotiq_ft_sensor_hardware/robotiq_ft_sensor_hardware.hpp
@@ -44,7 +44,7 @@
 #include "hardware_interface/types/hardware_interface_return_values.hpp"
 #include "hardware_interface/types/hardware_interface_type_values.hpp"
 #include "rclcpp/macros.hpp"
-#include "realtime_tools/realtime_buffer.h"
+#include "realtime_tools/realtime_buffer.hpp"
 #include "robotiq_ft_sensor_interfaces/srv/sensor_accessor.hpp"
 #include "rq_sensor_state.h"
 #include <geometry_msgs/msg/wrench_stamped.hpp>

--- a/robotiq_ft_sensor_hardware/src/rq_sensor_com.cpp
+++ b/robotiq_ft_sensor_hardware/src/rq_sensor_com.cpp
@@ -116,11 +116,11 @@ static INT_32 rq_com_write_port(UINT_8 const* const buf, UINT_32 buf_len);
 // Modbus functions
 static UINT_16 rq_com_compute_crc(UINT_8 const* adr, INT_32 length);
 static void rq_com_send_fc_03_request(UINT_16 base, UINT_16 n);
-static void rq_com_send_fc_16_request(INT_32 base, INT_32 n, UINT_8 const* const data);
+static void rq_com_send_fc_16_request(INT_32 base, UINT_32 n, UINT_8 const* const data);
 static INT_32 rq_com_wait_for_fc_03_echo(UINT_8* const data);
 static INT_32 rq_com_wait_for_fc_16_echo(void);
 static INT_8 rq_com_send_fc_03(UINT_16 base, UINT_16 n, UINT_16* const data);
-static INT_8 rq_com_send_fc_16(INT_32 base, INT_32 n, UINT_16 const* const data);
+static INT_8 rq_com_send_fc_16(INT_32 base, UINT_32 n, UINT_16 const* const data);
 
 static UINT_8 rq_com_identify_device(INT_8 const* const d_name);
 
@@ -588,18 +588,17 @@ static INT_8 rq_com_send_fc_03(UINT_16 base, UINT_16 n, UINT_16* const data)
 }
 
 /**
- * \fn static INT_8 rq_com_send_fc_16(INT_32 base, INT_32 n, UINT_16 * data)
+ * \fn static INT_8 rq_com_send_fc_16(INT_32 base, UINT_32 n, UINT_16 * data)
  * \brief Sends a write request to a number of registers
  * \param base Address of the first register to write to
  * \param n Number of registers to write
  * \param data buffer that contains data to write
  */
-static INT_8 rq_com_send_fc_16(INT_32 base, INT_32 n, UINT_16 const* const data)
+static INT_8 rq_com_send_fc_16(INT_32 base, UINT_32 n, UINT_16 const* const data)
 {
   INT_8 valid_answer = 0;
   UINT_8 data_request[n];
   UINT_16 retries = 0;
-  UINT_32 i;
 
   // precondition, null pointer
   if (data == NULL)
@@ -607,7 +606,7 @@ static INT_8 rq_com_send_fc_16(INT_32 base, INT_32 n, UINT_16 const* const data)
     return -1;
   }
 
-  for (i = 0; i < n; i++)
+  for (UINT_32 i = 0; i < n; i++)
   {
     if (i % 2 == 0)
     {
@@ -924,12 +923,12 @@ static INT_32 rq_com_wait_for_fc_03_echo(UINT_8* const data)
 }
 
 /**
- * \fn void modbus_send_fc_16_request(INT_32 base, INT_32 n, UINT_8 * data)
+ * \fn void modbus_send_fc_16_request(INT_32 base, UINT_32 n, UINT_8 * data)
  * \brief Sends a fc16 write request
  * \param base Address of the first register to write to
  * \param n Number of bytes to write
  */
-static void rq_com_send_fc_16_request(INT_32 base, INT_32 n, UINT_8 const* const data)
+static void rq_com_send_fc_16_request(INT_32 base, UINT_32 n, UINT_8 const* const data)
 {
   static UINT_8 buf[MP_BUFF_SIZE];
   INT_32 length = 0;
@@ -938,8 +937,7 @@ static void rq_com_send_fc_16_request(INT_32 base, INT_32 n, UINT_8 const* const
   UINT_8 reg[2];
   UINT_8 words[2];
   UINT_16 CRC;
-  INT_32 n2 = 0;
-  INT_32 i = 0;
+  UINT_32 n2 = 0;
 
   if (data == NULL)
   {
@@ -972,7 +970,7 @@ static void rq_com_send_fc_16_request(INT_32 base, INT_32 n, UINT_8 const* const
   buf[length++] = n2;
 
   // Copy data to the send buffer
-  for (i = 0; i < n; i++)
+  for (UINT_32 i = 0; i < n; i++)
   {
     buf[length++] = data[i];
   }
@@ -1120,7 +1118,7 @@ bool rq_com_get_valid_stream()
  */
 float rq_com_get_received_data(UINT_8 i)
 {
-  if (i >= 0 && i <= 5)
+  if (i <= 5)
   {
     return rq_com_received_data[i] - rq_com_received_data_offset[i];
   }

--- a/robotiq_ft_sensor_hardware/src/rq_sensor_state.cpp
+++ b/robotiq_ft_sensor_hardware/src/rq_sensor_state.cpp
@@ -239,7 +239,7 @@ static void rq_state_run(unsigned int max_retries)
  */
 float rq_state_get_received_data(UINT_8 i)
 {
-  if (i >= 0 && i <= 5)
+  if (i <= 5)
   {
     return rq_com_get_received_data(i);
   }


### PR DESCRIPTION
When compiling the `robotiq_ft_sensor_hardware` package with `colcon`, e.g.

```bash
colcon build --packages-up-to robotiq_ft_sensor_hardware
```

I obtain the following warnings:

```text
Starting >>> robotiq_ft_sensor_interfaces
Finished <<< robotiq_ft_sensor_interfaces [3.35s]                     
Starting >>> robotiq_ft_sensor_hardware
--- stderr: robotiq_ft_sensor_hardware                                
In file included from /usr/include/termios.h:25,
                 from /home/vpetrone/ros2_ws/src/rq_fts_ros2_driver/robotiq_ft_sensor_hardware/src/rq_sensor_com.cpp:49:
/usr/include/features.h:194:3: warning: #warning "_BSD_SOURCE and _SVID_SOURCE are deprecated, use _DEFAULT_SOURCE" [-Wcpp]
  194 | # warning "_BSD_SOURCE and _SVID_SOURCE are deprecated, use _DEFAULT_SOURCE"
      |   ^~~~~~~
/home/vpetrone/ros2_ws/src/rq_fts_ros2_driver/robotiq_ft_sensor_hardware/src/rq_sensor_state.cpp: In function ‘float rq_state_get_received_data(UINT_8)’:
/home/vpetrone/ros2_ws/src/rq_fts_ros2_driver/robotiq_ft_sensor_hardware/src/rq_sensor_state.cpp:242:9: warning: comparison is always true due to limited range of data type [-Wtype-limits]
  242 |   if (i >= 0 && i <= 5)
      |       ~~^~~~
/home/vpetrone/ros2_ws/src/rq_fts_ros2_driver/robotiq_ft_sensor_hardware/src/rq_sensor_com.cpp: In function ‘INT_8 rq_com_send_fc_16(INT_32, INT_32, const UINT_16*)’:
/home/vpetrone/ros2_ws/src/rq_fts_ros2_driver/robotiq_ft_sensor_hardware/src/rq_sensor_com.cpp:610:17: warning: comparison of integer expressions of different signedness: ‘UINT_32’ {aka ‘unsigned int’} and ‘INT_32’ {aka ‘int’} [-Wsign-compare]
  610 |   for (i = 0; i < n; i++)
      |               ~~^~~
/home/vpetrone/ros2_ws/src/rq_fts_ros2_driver/robotiq_ft_sensor_hardware/src/rq_sensor_com.cpp: In function ‘float rq_com_get_received_data(UINT_8)’:
/home/vpetrone/ros2_ws/src/rq_fts_ros2_driver/robotiq_ft_sensor_hardware/src/rq_sensor_com.cpp:1123:9: warning: comparison is always true due to limited range of data type [-Wtype-limits]
 1123 |   if (i >= 0 && i <= 5)
      |       ~~^~~~
---
Finished <<< robotiq_ft_sensor_hardware [10.2s]

Summary: 2 packages finished [13.8s]
  1 package had stderr output: robotiq_ft_sensor_hardware
```

This PR fixes the warnings related to the (un)signedness of variables.

With the changes introduced by this PR, the output of the same command is the following:

```text
Starting >>> robotiq_ft_sensor_interfaces
Finished <<< robotiq_ft_sensor_interfaces [0.48s]                     
Starting >>> robotiq_ft_sensor_hardware
--- stderr: robotiq_ft_sensor_hardware                              
In file included from /usr/include/termios.h:25,
                 from /home/vpetrone/ros2_ws/src/rq_fts_ros2_driver/robotiq_ft_sensor_hardware/src/rq_sensor_com.cpp:49:
/usr/include/features.h:194:3: warning: #warning "_BSD_SOURCE and _SVID_SOURCE are deprecated, use _DEFAULT_SOURCE" [-Wcpp]
  194 | # warning "_BSD_SOURCE and _SVID_SOURCE are deprecated, use _DEFAULT_SOURCE"
      |   ^~~~~~~
---
Finished <<< robotiq_ft_sensor_hardware [0.81s]

Summary: 2 packages finished [1.54s]
  1 package had stderr output: robotiq_ft_sensor_hardware
```