### PR TITLE
add _joint to joint name and fix typo

### DIFF
--- a/robotiq_ft_sensor_description/urdf/robotiq_ft300.urdf.xacro
+++ b/robotiq_ft_sensor_description/urdf/robotiq_ft300.urdf.xacro
@@ -56,13 +56,13 @@
         </link>
 
          <!-- Connect force sensor with mounting/coupling plate -->
-        <joint name="${tf_prefix}ft300_mounting_plate" type="fixed">
+        <joint name="${tf_prefix}ft300_mounting_plate_joint" type="fixed">
             <origin xyz="0 0 0.0415" rpy="0 ${pi} 0"/> 
             <parent link="${tf_prefix}ft300_mounting_plate" />
             <child link="${tf_prefix}ft300_sensor" />
         </joint>
 
-        <joint name="${tf_prefix}measurment_joint" type="fixed">
+        <joint name="${tf_prefix}measurement_joint" type="fixed">
             <origin xyz="0 0 0" rpy="0 ${pi} ${-pi/2}" />
             <parent link="${tf_prefix}ft300_sensor" />
             <child link="${tf_prefix}robotiq_ft_frame_id" />


### PR DESCRIPTION
1) fix joint name:
ft300_mounting_plate-> ft300_mounting_plate_joint

2) fix typo:
measurment_joint -> measurement_joint

Without 1) the code does not work (I tried it in simulation).